### PR TITLE
fix: schema.data.gouv.fr file

### DIFF
--- a/schemas.yml
+++ b/schemas.yml
@@ -1,0 +1,7 @@
+title: "Données essentielles des marchés publics français"
+description : "Données des attributions de marchés publics et de contrats de concessions supérieures à 40 000 euros."
+homepage: "https://github.com/139bercy/format-commande-publique"
+schemas:
+  -
+    path: "marches.json"
+    title: "Contrats de commande publique JSON"


### PR DESCRIPTION
Le fichier schemas.yml a été effacé lors des dernières pull requests. Ce fichier est important pour schema.data.gouv.fr, il faut qu'il soit présent dans le repo.