### PR TITLE
fix: correct jsonschema for marches.json

### DIFF
--- a/marches.json
+++ b/marches.json
@@ -562,13 +562,13 @@
               "title": "Titulaires modifiés",
               "description": "Liste des titulaires après modification",
               "$ref": "#/definitions/marche/definitions/Titulaire"
-            },
-            "required": [
-              "id",
-              "datePublicationDonneesModification",
-              "dateNotificationModification"
-            ]
-          }
+            }
+          },
+          "required": [
+            "id",
+            "datePublicationDonneesModification",
+            "dateNotificationModification"
+          ]
         }
       }
     },


### PR DESCRIPTION
le fichier marches.json contenait une erreur qui faisait que celui-ci n'était pas valide au standard jsonschema.